### PR TITLE
sys.setdefaultencoding() was removed in Python 3

### DIFF
--- a/test.py
+++ b/test.py
@@ -15,8 +15,11 @@ import numpy as np
 import codecs
 import math
 
-reload(sys)  
-sys.setdefaultencoding('utf8')
+try:
+	reload(sys)  # Python 2
+	sys.setdefaultencoding('utf8')
+except NameError:
+	pass         # Python 3
 
 from config import cfg
 from util import LoadClasses


### PR DESCRIPTION
__sys.setdefaultencoding()__ was removed in Python 3 because '__utf8__' is already the default and __reload()__ was moved because it was being overused and created glitches that were difficult to debug.