### PR TITLE
TabError: inconsistent use of tabs and spaces in indentation

### DIFF
--- a/train.py
+++ b/train.py
@@ -167,7 +167,7 @@ try:
 			if currTrainLoss < Loss: LogFile.write("Bad\n")
 			else: LogFile.write("Good\n")
 
-		  	start += cfg.BatchSize
+			start += cfg.BatchSize
 			end += cfg.BatchSize
 			batch += 1
 

--- a/util.py
+++ b/util.py
@@ -16,7 +16,7 @@ from config import cfg
 
 def LoadList(path):
     with open(path) as vlist:
-	return vlist.readlines()
+        return vlist.readlines()
 
 #Ref: https://stackoverflow.com/questions/33949786/how-could-i-use-batch-normalization-in-tensorflow
 def batch_norm_conv(x, n_out, phase_train):


### PR DESCRIPTION
Python 3 treats TabErros as syntax errors so avoid mixing tabs and spaces in indentation.

[flake8](http://flake8.pycqa.org) testing of https://github.com/0x454447415244/HandwritingRecognitionSystem on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./train.py:170:27: E999 TabError: inconsistent use of tabs and spaces in indentation
		  	start += cfg.BatchSize
                          ^
./util.py:19:25: E999 TabError: inconsistent use of tabs and spaces in indentation
	return vlist.readlines()
                        ^
2     E999 TabError: inconsistent use of tabs and spaces in indentation
2
```